### PR TITLE
Issue #1 - Store job manifest in the project

### DIFF
--- a/inception-humanprotocol-adapter/pom.xml
+++ b/inception-humanprotocol-adapter/pom.xml
@@ -73,6 +73,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolProjectInitializer.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolProjectInitializer.java
@@ -90,6 +90,7 @@ public class HumanProtocolProjectInitializer
     private @Autowired ProjectService projectService;
     private @Autowired UserDao userService;
     private @Autowired InviteService inviteService;
+    private @Autowired HumanProtocolService hmtService;
     
     private final JobManifest manifest;
 

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolService.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolService.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package io.github.reckart.inception.humanprotocol;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import io.github.reckart.inception.humanprotocol.model.JobManifest;
+
+public interface HumanProtocolService
+{
+    Optional<JobManifest> readJobManifest(Project aProject) throws IOException;
+
+    /**
+     * Import a job manifest directly into the project from a remote URL. This ensures that any
+     * information that is not represented in the {@link JobManifest} class is still present in the
+     * persisted manifest and can (if need be) accessed at a later time, e.g. when the 
+     * {@link JobManifest} has been extended to support the new information.
+     */
+    void importJobManifest(Project aProject, URL aManifestUrl) throws IOException;
+}

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolServiceImpl.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolServiceImpl.java
@@ -1,0 +1,83 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package io.github.reckart.inception.humanprotocol;
+
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.newOutputStream;
+import static org.apache.commons.io.IOUtils.copyLarge;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import io.github.reckart.inception.humanprotocol.config.HumanProtocolAutoConfiguration;
+import io.github.reckart.inception.humanprotocol.model.JobManifest;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link HumanProtocolAutoConfiguration#humanProtocolService}.
+ * </p>
+ */
+public class HumanProtocolServiceImpl
+    implements HumanProtocolService
+{
+    private final RepositoryProperties repositoryProperties;
+
+    public HumanProtocolServiceImpl(RepositoryProperties aRepositoryProperties)
+    {
+        repositoryProperties = aRepositoryProperties;
+    }
+
+    @Override
+    public synchronized Optional<JobManifest> readJobManifest(Project aProject) throws IOException
+    {
+        Path manifestFile = getManifestFile(aProject);
+
+        if (!exists(manifestFile)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(JobManifestUtils.loadManifest(manifestFile.toFile()));
+    }
+    
+    @Override
+    public synchronized void importJobManifest(Project aProject, URL aManifestUrl) throws IOException
+    {
+        Path manifestFile = getManifestFile(aProject);
+
+        if (!exists(manifestFile)) {
+            createDirectories(manifestFile.getParent());
+        }
+        
+        try (InputStream is = aManifestUrl.openStream();
+                OutputStream os = newOutputStream(manifestFile)) {
+            copyLarge(is, os);
+        }
+    }
+
+    public Path getManifestFile(Project aProject)
+    {
+        return repositoryProperties.getPath().toPath().resolve("hmt").resolve("job-manifest.json");
+    }
+}

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/config/HumanProtocolAutoConfiguration.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/config/HumanProtocolAutoConfiguration.java
@@ -25,8 +25,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import io.github.reckart.inception.humanprotocol.HumanProtocolController;
 import io.github.reckart.inception.humanprotocol.HumanProtocolControllerImpl;
+import io.github.reckart.inception.humanprotocol.HumanProtocolService;
+import io.github.reckart.inception.humanprotocol.HumanProtocolServiceImpl;
 import io.swagger.v3.oas.models.info.Info;
 
 @Configuration
@@ -36,9 +39,9 @@ public class HumanProtocolAutoConfiguration
 {
     @Bean
     public HumanProtocolController humanProtocolController(ApplicationContext aApplicationContext,
-            ProjectService aProjectService)
+            ProjectService aProjectService, HumanProtocolService aHmtService)
     {
-        return new HumanProtocolControllerImpl(aApplicationContext, aProjectService);
+        return new HumanProtocolControllerImpl(aApplicationContext, aProjectService, aHmtService);
     }
 
     @Bean
@@ -57,5 +60,11 @@ public class HumanProtocolAutoConfiguration
     public HumanProtocolWebInitializer humanProtocolWebInitializer()
     {
         return new HumanProtocolWebInitializer();
+    }
+
+    @Bean
+    public HumanProtocolService humanProtocolService(RepositoryProperties aRepositoryProperties)
+    {
+        return new HumanProtocolServiceImpl(aRepositoryProperties);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
         <artifactId>inception-humanprotocol-adapter</artifactId>
         <version>0.0.1-SNAPSHOT</version>
       </dependency>
+
+      <dependency>
+        <groupId>net.javacrumbs.json-unit</groupId>
+        <artifactId>json-unit-assertj</artifactId>
+        <version>2.25.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
- Added a HumanProtocolService for metadata storage and access
- Import the raw job manifest into the project
- Add method allowing to retrieve the (parsed) manifest from the project when required
- Check that the job address used in the job submission matches the job ID in the manifest
- Slightly extended unit test