### PR TITLE
#3 - Store the job request as part of the project

### DIFF
--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolControllerImpl.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolControllerImpl.java
@@ -24,8 +24,6 @@ import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -87,15 +85,11 @@ public class HumanProtocolControllerImpl
         projectService.createProject(project);
         
         try {
+            hmtService.writeJobRequest(project, aJobRequest);
+            
             hmtService.importJobManifest(project, aJobRequest.getJobManifest().toURL());
+            
             JobManifest manifest = hmtService.readJobManifest(project).get();
-            
-            if (!Objects.equals(manifest.getJobId(), aJobRequest.getJobAddress())) {
-                throw new IllegalArgumentException("Job ID in manifest [" + manifest.getJobId()
-                        + "] does not match job ID in request [" + aJobRequest.getJobAddress()
-                        + "]");
-            }
-            
             project.setDescription(manifest.getRequesterQuestion().get("en"));
             projectService.updateProject(project);
     

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolProjectInitializer.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolProjectInitializer.java
@@ -90,7 +90,6 @@ public class HumanProtocolProjectInitializer
     private @Autowired ProjectService projectService;
     private @Autowired UserDao userService;
     private @Autowired InviteService inviteService;
-    private @Autowired HumanProtocolService hmtService;
     
     private final JobManifest manifest;
 

--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolService.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolService.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.Optional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import io.github.reckart.inception.humanprotocol.messages.JobRequest;
 import io.github.reckart.inception.humanprotocol.model.JobManifest;
 
 public interface HumanProtocolService
@@ -34,4 +35,8 @@ public interface HumanProtocolService
      * {@link JobManifest} has been extended to support the new information.
      */
     void importJobManifest(Project aProject, URL aManifestUrl) throws IOException;
+
+    Optional<JobRequest> readJobRequest(Project aProject) throws IOException;
+    
+    void writeJobRequest(Project aProject, JobRequest aJobRequest) throws IOException;
 }


### PR DESCRIPTION
- Store the job submission request
- Remove validation that the job Id in the job submission and the job address in the manifest are the same - they are not