### PR TITLE
#35 - Unable to create job if job address is only numeric

### DIFF
--- a/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolControllerImpl.java
+++ b/inception-humanprotocol-adapter/src/main/java/io/github/reckart/inception/humanprotocol/HumanProtocolControllerImpl.java
@@ -132,7 +132,11 @@ public class HumanProtocolControllerImpl
 
     public void createJob(JobRequest aJobRequest) throws IOException
     {
-        Project project = new Project(aJobRequest.getJobAddress());
+        String projectSlug = projectService.deriveSlugFromName("job-"+aJobRequest.getJobAddress());
+        projectSlug = projectService.deriveUniqueSlug(projectSlug);
+        Project project = new Project();
+        project.setSlug(projectSlug);
+        project.setName("Job: " + aJobRequest.getJobAddress());
         projectService.createProject(project);
 
         try {

--- a/inception-humanprotocol-adapter/src/test/java/io/github/reckart/inception/humanprotocol/adapter/JobSubmissionTest.java
+++ b/inception-humanprotocol-adapter/src/test/java/io/github/reckart/inception/humanprotocol/adapter/JobSubmissionTest.java
@@ -227,17 +227,18 @@ public class JobSubmissionTest
                 .as("Starting with emtpy database (no projects)").hasSize(0);
 
         JobRequest jobRequest = createJobRequest();
+        String jobSlug = "job-" + jobRequest.getJobAddress();
         postJob(createJobRequest());
 
         // Validate project has been properly created
-        assertThat(projectService.existsProjectWithSlug(jobRequest.getJobAddress())) //
+        assertThat(projectService.existsProjectWithSlug(jobSlug)) //
                 .as("Project has been created from the job manifest using the job address as name")
                 .isTrue();
 
-        Project project = projectService.getProjectBySlug(jobRequest.getJobAddress());
+        Project project = projectService.getProjectBySlug(jobSlug);
         assertThat(project.getSlug()) //
                 .as("Project slug does not match") //
-                .isEqualTo(jobRequest.getJobAddress());
+                .isEqualTo(jobSlug);
         assertThat(project.getName()) //
                 .as("Project title does not match") //
                 .isEqualTo("Test project");


### PR DESCRIPTION
- Instead of using the job address directly as the URL slug, prefix it always with `job-` - that prevents the need for padding if the address is too short or starts with a numeric characters
- If that is still not enough, try to derive a unique and valid slug from the `job-<addr>` construct
- Updated tests